### PR TITLE
TSV-436: Using new email api to send emails

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -21,12 +21,12 @@ import uk.gov.hmrc.play.config.ServicesConfig
 
 trait AppConfig {
   def platformFrontendHost: String
-  def path: String
+  def emailServicePath: String
 }
 
 object AppConfig extends AppConfig with ServicesConfig {
   override val platformFrontendHost = getConfigValueFor("platform.frontend.host")
-  override val path = getConfigValueFor("microservice.services.email.path")
+  override val emailServicePath = getConfigValueFor("microservice.services.email.path")
 
   private def getConfigValueFor(key: String) = configuration.getString(key).getOrElse(throw new Exception(s"Missing configuration key: $key"))
 }

--- a/app/uk/gov/hmrc/emailverification/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/emailverification/connectors/EmailConnector.scala
@@ -29,20 +29,20 @@ object SendEmailRequest {
 }
 
 trait EmailConnector {
-  def config: AppConfig
+  def servicePath: String
 
-  def serviceUrl: String
+  def baseServiceUrl: String
 
   def http: WSPost
 
   def sendEmail(to: String, templateId: String, params: Map[String, String])(implicit hc: HeaderCarrier) =
-    http.POST(s"$serviceUrl${config.path}/send-templated-email", SendEmailRequest(Seq(to), templateId, params))
+    http.POST(s"$baseServiceUrl$servicePath/hmrc/email", SendEmailRequest(Seq(to), templateId, params))
 }
 
 object EmailConnector extends EmailConnector with ServicesConfig {
-  override lazy val config = AppConfig
+  override lazy val servicePath = AppConfig.emailServicePath
 
-  override lazy val serviceUrl = baseUrl("email")
+  override lazy val baseServiceUrl = baseUrl("email")
 
   override lazy val http = WSHttp
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -12,6 +12,9 @@
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>error</level>
+        </filter>
     </appender>
 
     <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">

--- a/it/support/EmailStub.scala
+++ b/it/support/EmailStub.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.crypto.CryptoWithKeysFromConfig
 import scala.collection.JavaConverters._
 
 object EmailStub extends MockitoSugar with ShouldMatchers {
-  private val emailMatchingStrategy = urlEqualTo("/send-templated-email")
+  private val emailMatchingStrategy = urlEqualTo("/hmrc/email")
   private val emailEventStub = postRequestedFor(emailMatchingStrategy)
   private lazy val crypto = CryptoWithKeysFromConfig("queryParameter.encryption")
 

--- a/it/uk/gov/hmrc/PayloadErrorHandlingISpec.scala
+++ b/it/uk/gov/hmrc/PayloadErrorHandlingISpec.scala
@@ -99,7 +99,7 @@ class PayloadErrorHandlingISpec extends IntegrationBaseSpec with GivenWhenThen {
       response.body shouldBe
         Json.parse("""{
                      |  "code":"UPSTREAM_ERROR",
-                     |  "message":"POST of 'http://localhost:11111/send-templated-email' returned 500. Response body: 'some-5xx-message'"
+                     |  "message":"POST of 'http://localhost:11111/hmrc/email' returned 500. Response body: 'some-5xx-message'"
                      |}""".stripMargin).toString()
     }
 
@@ -112,7 +112,7 @@ class PayloadErrorHandlingISpec extends IntegrationBaseSpec with GivenWhenThen {
       response.body shouldBe
         Json.parse("""{
                      |  "code":"UPSTREAM_ERROR",
-                     |  "message":"POST of 'http://localhost:11111/send-templated-email' returned 404 (Not Found). Response body: 'some-4xx-message'"
+                     |  "message":"POST of 'http://localhost:11111/hmrc/email' returned 404 (Not Found). Response body: 'some-4xx-message'"
                      |}""".stripMargin).toString()
     }
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/helpers/MaterializerSupport.scala
+++ b/test/helpers/MaterializerSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emailverification/MockitoSugarRush.scala
+++ b/test/uk/gov/hmrc/emailverification/MockitoSugarRush.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emailverification/connectors/PlatformAnalyticsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/connectors/PlatformAnalyticsConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emailverification/controllers/EmailVerificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/controllers/EmailVerificationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emailverification/repositories/VerificationTokenMongoRepositorySpec.scala
+++ b/test/uk/gov/hmrc/emailverification/repositories/VerificationTokenMongoRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emailverification/repositories/VerifiedEmailMongoRepositorySpec.scala
+++ b/test/uk/gov/hmrc/emailverification/repositories/VerifiedEmailMongoRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emailverification/services/VerificationLinkServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/VerificationLinkServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replaced call to `POST /send-templated-email` with `POST /hmrc/email`.