### PR TITLE
Corrected test-only passcode route & JSON in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,12 @@ X-Session-ID: SomeSessionId
 
 ```json
 {
-  "passcode": "ATERRT"
+  "passcodes": [
+    {
+      "email": "test@example.com",
+      "passcode": "ATERRT"
+    }   
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ Check if email address is verified or not, if verified return 200 with the email
 }
 ```
 
-## GET /test-only/passcode
+## GET /test-only/passcodes
 
 Retrieves the generated passcode for a given session ID provided in the headers
 
 **Example Request**
 
 ```
-GET /test-only/passcode
+GET /test-only/passcodes
 
 X-Session-ID: SomeSessionId
 ```


### PR DESCRIPTION
My team recently did some work on our service to integrate with this test-only passcode route and we noticed it was slightly different in the Readme compared to what is listed in the routes file.

**Edit:** I have also added an extra commit to show the correct JSON structure returned by this endpoint as this tripped my team up when first trying to use it