### PR TITLE
CIR-1702: Add config for switching between live and canned email v2 service

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -43,9 +43,10 @@ class AppConfig @Inject() (val config: Configuration) {
   lazy val verifiedEmailRepoTTLDays: Int = config.get[Int]("verifiedEmailRepo.ttlDays")
 
   // V2
-  val appName: String = config.get[String]("appName")
+  lazy val appName: String = config.get[String]("appName")
+  lazy val useCannedEmails: Boolean = config.get[Boolean]("microservice.services.use-canned-emails")
 
-  lazy val accessRequestFormUrl = config.get[String]("microservice.services.access-control.request.formUrl")
-  lazy val accessControlEnabled = config.get[Boolean]("microservice.services.access-control.enabled")
-  lazy val accessControlAllowList = config.get[Seq[String]]("microservice.services.access-control.allow-list").toSet
+  lazy val accessRequestFormUrl: String = config.get[String]("microservice.services.access-control.request.formUrl")
+  lazy val accessControlEnabled: Boolean = config.get[Boolean]("microservice.services.access-control.enabled")
+  lazy val accessControlAllowList: Set[String] = config.get[Seq[String]]("microservice.services.access-control.allow-list").toSet
 }

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import com.google.inject.{AbstractModule, Provides}
+import play.api.{Configuration, Environment}
+import uk.gov.hmrc.emailverification.connectors.EmailConnector
+import uk.gov.hmrc.emailverification.services.{CannedEmailV2Service, EmailV2Service, LiveEmailV2Service}
+
+class Module(env: Environment, config: Configuration) extends AbstractModule {
+  @Provides
+  def provideEmailV2Service(appConfig: AppConfig, emailConnector: EmailConnector): EmailV2Service = {
+    if (appConfig.useCannedEmails) new CannedEmailV2Service()
+    else new LiveEmailV2Service(emailConnector)
+  }
+}

--- a/app/uk/gov/hmrc/emailverification/services/EmailService.scala
+++ b/app/uk/gov/hmrc/emailverification/services/EmailService.scala
@@ -38,21 +38,4 @@ class EmailService @Inject() (emailConnector: EmailConnector) {
 
     emailConnector.sendEmail(emailAddress, templateId, params).map(_ => ())
   }
-
-  def sendCode(email: String, verificationCode: String, serviceName: String, lang: Language)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[SendCodeResult] = {
-    val params = Map(
-      "passcode"  -> verificationCode,
-      "team_name" -> serviceName
-    )
-
-    val templateId = lang match {
-      case English => "email_verification_passcode"
-      case Welsh   => "email_verification_passcode_welsh"
-    }
-
-    emailConnector.sendEmail(email, templateId, params).map {
-      case httpResponse if httpResponse.status / 200 == 1 => SendCodeResult.codeSent()
-      case httpResponse                                   => SendCodeResult.codeNotSent(httpResponse.body)
-    }
-  }
 }

--- a/app/uk/gov/hmrc/emailverification/services/EmailV2Service.scala
+++ b/app/uk/gov/hmrc/emailverification/services/EmailV2Service.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emailverification.services
+
+import uk.gov.hmrc.emailverification.connectors.EmailConnector
+import uk.gov.hmrc.emailverification.models._
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+sealed trait EmailV2Service {
+  def sendCode(email: String, verificationCode: String, serviceName: String, lang: Language)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[SendCodeResult]
+}
+
+class LiveEmailV2Service @Inject() (emailConnector: EmailConnector) extends EmailV2Service {
+  def sendCode(email: String, verificationCode: String, serviceName: String, lang: Language)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[SendCodeResult] = {
+    val params = Map(
+      "passcode"  -> verificationCode,
+      "team_name" -> serviceName
+    )
+
+    val templateId = lang match {
+      case English => "email_verification_passcode"
+      case Welsh   => "email_verification_passcode_welsh"
+    }
+
+    emailConnector.sendEmail(email, templateId, params).map {
+      case httpResponse if httpResponse.status / 200 == 1 => SendCodeResult.codeSent()
+      case httpResponse                                   => SendCodeResult.codeNotSent(httpResponse.body)
+    }
+  }
+}
+
+class CannedEmailV2Service @Inject() () extends EmailV2Service {
+  def sendCode(email: String, verificationCode: String, serviceName: String, lang: Language)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[SendCodeResult] =
+    Future.successful(email match {
+      case "success@sender.com"   => SendCodeResult.codeSent()
+      case "unsuccess@sender.com" => SendCodeResult.codeNotSent("Could not send email")
+      case _                      => SendCodeResult.codeNotSent("Invalid email")
+    })
+}

--- a/app/uk/gov/hmrc/emailverification/services/EmailVerificationV2Service.scala
+++ b/app/uk/gov/hmrc/emailverification/services/EmailVerificationV2Service.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class EmailVerificationV2Service @Inject() (
   verificationCodeGenerator: PasscodeGenerator,
   verificationCodeRepository: VerificationCodeV2MongoRepository,
-  emailService: EmailService,
+  emailService: EmailV2Service,
   auditService: AuditV2Service
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends Logging {

--- a/conf/appV2.routes
+++ b/conf/appV2.routes
@@ -1,0 +1,3 @@
+# Stripped down api only endpoints
+POST        /send-code                              uk.gov.hmrc.emailverification.controllers.EmailVerificationV2Controller.sendCode()
+POST        /verify-code                            uk.gov.hmrc.emailverification.controllers.EmailVerificationV2Controller.verifyCode()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,20 +14,21 @@
 
 include "backend.conf"
 
-appName=email-verification
+appName = email-verification
 
 # Define any modules used here
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
+play.modules.enabled += "config.Module"
 
 play.http.errorHandler = "uk.gov.hmrc.emailverification.ErrorHandlerOverride"
 
 # Session configuration
 # ~~~~~
-application.session.httpOnly=false
+application.session.httpOnly = false
 
-application.session.secure=false
+application.session.secure = false
 
 # The application languages
 # ~~~~~
@@ -60,57 +61,58 @@ passcodeExpiryMinutes = 15
 verificationCodeExpiryMinutes = 15 # minutes
 
 verifiedEmailRepo {
-    hashKey = somehashkey
-    replaceIndex = false # If true rebuilds indexes on startup
-    ttlDays = 2555 # 2555 days = 7 years
+  hashKey = somehashkey
+  replaceIndex = false # If true rebuilds indexes on startup
+  ttlDays = 2555 # 2555 days = 7 years
 }
 
 controllers {
-    confidenceLevel = 250
+  confidenceLevel = 250
 
   uk.gov.hmrc.emailverification.controllers.EmailVerificationController = {
-      needsAuth = false
-      needsLogging = true
-      needsAuditing = true
-    }
+    needsAuth = false
+    needsLogging = true
+    needsAuditing = true
+  }
 
-    uk.gov.hmrc.emailverification.controllers.EmailVerificationV2Controller = {
-      needsAuth = false
-      needsLogging = true
-      needsAuditing = true
-    }
+  uk.gov.hmrc.emailverification.controllers.EmailVerificationV2Controller = {
+    needsAuth = false
+    needsLogging = true
+    needsAuditing = true
+  }
 
 }
 
 mongodb {
-    uri = "mongodb://localhost:27017/email-verification"
+  uri = "mongodb://localhost:27017/email-verification"
 }
 
 platform.frontend.host = "http://localhost:9890"
 
 microservice {
-    metrics.graphite.enabled = true
+  metrics.graphite.enabled = true
 
-    services {
-        auth {
-            host=localhost
-            port=8500
-        }
-
-      # Used for v2 only
-      access-control {
-        request.formUrl = "https://forms.office.com/Pages/ResponsePage.aspx?id=PPdSrBr9mkqOekokjzE54cRTj_GCzpRJqsT4amG0JK1UMkpBS1NUVDhWR041NjJWU0lCMVZUNk5NTi4u"
-        enabled = "false"
-        allow-list = []
-      }
-
-      # Locally you cannot send emails so for performance and integration tests override this to call the email-verification-stubs
-        email {
-            host = localhost
-            port = 8300
-            path = ""
-        }
+  services {
+    auth {
+      host = localhost
+      port = 8500
     }
+
+    # Used for v2 only
+    use-canned-emails = true
+    access-control {
+      request.formUrl = "https://forms.office.com/Pages/ResponsePage.aspx?id=PPdSrBr9mkqOekokjzE54cRTj_GCzpRJqsT4amG0JK1UMkpBS1NUVDhWR041NjJWU0lCMVZUNk5NTi4u"
+      enabled = "false"
+      allow-list = []
+    }
+
+    # Locally you cannot send emails so for performance and integration tests override this to call the email-verification-stubs
+    email {
+      host = localhost
+      port = 8300
+      path = ""
+    }
+  }
 }
 
 # the value below is valid for local environment only
@@ -118,8 +120,8 @@ token.encryption.key = "gvBoGdgzqG1AarzF1LY0zQ=="
 
 # reduce log spam in tests
 mongo-async-driver.pekka {
-    log-dead-letters = off
-    log-dead-letters-during-shutdown = off
+  log-dead-letters = off
+  log-dead-letters-during-shutdown = off
 }
 
 http-verbs.retries.ssl-engine-closed-already.enabled = true

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,5 @@
 # Add all the application routes to the app.routes file
 ->        /email-verification           app.Routes
-->        /email-verification/v2        appv2.Routes
-->        /                             appv2.Routes
+->        /email-verification/v2        appV2.Routes
+->        /                             appV2.Routes
 ->        /                             health.Routes

--- a/it/test/uk/gov/hmrc/emailverification/EmailVerificationV2ControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/emailverification/EmailVerificationV2ControllerISpec.scala
@@ -72,7 +72,7 @@ class EmailVerificationV2ControllerISpec extends AnyWordSpec with OptionValues w
       "sendCode when a valid email is provided" in {
         val response = resourceRequest(s"/email-verification/v2/send-code")
           .withHttpHeaders(HeaderNames.USER_AGENT -> "test-user")
-          .post(Json.parse(s"""{"email":"joe@bloggs.com"}"""))
+          .post(Json.parse(s"""{"email":"success@sender.com"}"""))
           .futureValue
 
         response.status                       shouldBe Status.OK
@@ -82,14 +82,14 @@ class EmailVerificationV2ControllerISpec extends AnyWordSpec with OptionValues w
       "verify code successfully when provided the correct verification code" in {
         val retrieveVerificationCodeResponse = resourceRequest(s"/test-only/retrieve/verification-code")
           .withHttpHeaders(HeaderNames.USER_AGENT -> "test-user")
-          .post(Json.parse("""{"email":"joe@bloggs.com"}"""))
+          .post(Json.parse("""{"email":"success@sender.com"}"""))
           .futureValue
         retrieveVerificationCodeResponse.status shouldBe Status.OK
         val verificationCode = (retrieveVerificationCodeResponse.json \ "verificationCode").as[String]
 
         val response = resourceRequest(s"/email-verification/v2/verify-code")
           .withHttpHeaders(HeaderNames.USER_AGENT -> "test-user")
-          .post(Json.parse(s"""{"email":"joe@bloggs.com", "verificationCode":"$verificationCode"}"""))
+          .post(Json.parse(s"""{"email":"success@sender.com", "verificationCode":"$verificationCode"}"""))
           .futureValue
         response.status                       shouldBe Status.OK
         (response.json \ "status").as[String] shouldBe "CODE_VERIFIED"

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -27,6 +27,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers {
     "be available when configuration is defined" in new Setup(
       Map(
         "appName"                                              -> "the-app-name",
+        "microservice.services.use-canned-emails"              -> true,
         "platform.frontend.host"                               -> "some-host",
         "microservice.services.email.path"                     -> "some-path",
         "microservice.services.access-control.request.formUrl" -> "access-request-form-url",
@@ -34,6 +35,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers {
         "microservice.services.access-control.allow-list"      -> List()
       )
     ) {
+      appConfig.appName                shouldBe "the-app-name"
+      appConfig.useCannedEmails        shouldBe true
       appConfig.platformFrontendHost   shouldBe "some-host"
       appConfig.emailServicePath       shouldBe "some-path"
       appConfig.accessRequestFormUrl   shouldBe "access-request-form-url"
@@ -42,9 +45,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers {
     }
 
     "throw exceptions when configuration not defined" in new Setup(
-      Map(
-        "appName" -> "the-app-name"
-      )
+      Map()
     ) {
       val exception1: RuntimeException = intercept[RuntimeException](appConfig.platformFrontendHost)
       exception1.getMessage shouldBe s"hardcoded value: No configuration setting found for key 'platform'"
@@ -60,6 +61,12 @@ class AppConfigSpec extends AnyWordSpec with Matchers {
 
       val exception5: RuntimeException = intercept[RuntimeException](appConfig.accessControlAllowList)
       exception5.getMessage shouldBe s"hardcoded value: No configuration setting found for key 'microservice'"
+
+      val exception6: RuntimeException = intercept[RuntimeException](appConfig.useCannedEmails)
+      exception6.getMessage shouldBe s"hardcoded value: No configuration setting found for key 'microservice'"
+
+      val exception7: RuntimeException = intercept[RuntimeException](appConfig.appName)
+      exception7.getMessage shouldBe s"hardcoded value: No configuration setting found for key 'appName'"
     }
   }
 

--- a/test/uk/gov/hmrc/emailverification/services/EmailVerificationV2ServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/EmailVerificationV2ServiceSpec.scala
@@ -67,7 +67,7 @@ class EmailVerificationV2ServiceSpec extends RepositoryBaseSpec {
 
     val mockAuditService: AuditV2Service = mock[AuditV2Service]
 
-    val mockEmailService: EmailService = mock[EmailService]
+    val mockEmailService: EmailV2Service = mock[EmailV2Service]
     val emailVerificationService = new EmailVerificationV2Service(mockVerificationCodeGenerator, verificationRepository, mockEmailService, mockAuditService)
   }
 

--- a/test/uk/gov/hmrc/emailverification/services/SendCodeServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/SendCodeServiceSpec.scala
@@ -140,7 +140,7 @@ class SendCodeServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
 
     val mockAuditService: AuditV2Service = mock[AuditV2Service]
 
-    val emailServiceMock: EmailService = mock[EmailService]
+    val emailServiceMock: EmailV2Service = mock[EmailV2Service]
 
     val verifyService =
       new EmailVerificationV2Service(passcodeGeneratorMock, verificationRepository, emailServiceMock, mockAuditService)


### PR DESCRIPTION
NOTE: The default is canned data - the microservice.services.use-canned-emails should be overridden in the environments as required.
