### PR TITLE
CIR-2099 Dependency uplift

### DIFF
--- a/app/uk/gov/hmrc/emailverification/controllers/BaseControllerWithJsonErrorHandling.scala
+++ b/app/uk/gov/hmrc/emailverification/controllers/BaseControllerWithJsonErrorHandling.scala
@@ -16,20 +16,21 @@
 
 package uk.gov.hmrc.emailverification.controllers
 
-import javax.inject.Inject
 import play.api.libs.json._
 import play.api.mvc.{ControllerComponents, Request, Result}
 import uk.gov.hmrc.emailverification.models.ErrorResponse
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import javax.inject.Inject
 import scala.concurrent.Future
+import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 abstract class BaseControllerWithJsonErrorHandling @Inject() (cc: ControllerComponents) extends BackendController(cc) {
 
   private val separatorChar: String = ";"
 
-  override protected def withJsonBody[T](f: T => Future[Result])(implicit request: Request[JsValue], m: Manifest[T], reads: Reads[T]): Future[Result] =
+  override protected def withJsonBody[T](f: T => Future[Result])(implicit request: Request[JsValue], ct: ClassTag[T], reads: Reads[T]): Future[Result] =
     Try(request.body.validate[T]) match {
       case Success(JsSuccess(payload, _)) => f(payload)
       case Success(JsError(errs)) =>

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 import uk.gov.hmrc.DefaultBuildSettings
 
 ThisBuild / majorVersion := 1
-ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / scalaVersion := "2.13.16"
 
 lazy val microservice = Project("email-verification", file("."))
   .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) *)
-  .settings(DefaultBuildSettings.defaultSettings() *)
   .settings(scalafmtOnCompile := true)
   .settings(ScoverageSettings())
   .settings(scalacOptions ++= Seq(
@@ -18,7 +17,6 @@ lazy val microservice = Project("email-verification", file("."))
     libraryDependencies ++= AppDependencies(),
     retrieveManaged := true
   )
-  .settings(resolvers += Resolver.jcenterRepo)
   .settings(PlayKeys.playDefaultPort := 9891)
 
 lazy val it = project

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,13 +70,11 @@ controllers {
   confidenceLevel = 250
 
   uk.gov.hmrc.emailverification.controllers.EmailVerificationController = {
-    needsAuth = false
     needsLogging = true
     needsAuditing = true
   }
 
   uk.gov.hmrc.emailverification.controllers.EmailVerificationV2Controller = {
-    needsAuth = false
     needsLogging = true
     needsAuditing = true
   }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
   private val bootstrapVersion = "9.0.0"
-  private val hmrcMongoVersion = "2.0.0"
+  private val hmrcMongoVersion = "2.6.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,7 +1,7 @@
 import sbt.*
 
 object AppDependencies {
-  private val bootstrapVersion = "9.0.0"
+  private val bootstrapVersion = "9.12.0"
   private val hmrcMongoVersion = "2.6.0"
 
   private val compile: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
   )
 
   private val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"                  %% "government-gateway-test-play-30" % "6.0.0",
+    "uk.gov.hmrc"                  %% "government-gateway-test-play-30" % "7.1.0",
     "uk.gov.hmrc"                  %% "bootstrap-test-play-30"          % bootstrapVersion,
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-test-play-30"         % hmrcMongoVersion,
     "com.fasterxml.jackson.module" %% "jackson-module-scala"            % "2.17.0",

--- a/project/ScoverageSettings.scala
+++ b/project/ScoverageSettings.scala
@@ -2,12 +2,20 @@ import sbt.*
 import scoverage.*
 
 object ScoverageSettings {
-  def apply(): Seq[Def.Setting[?]] = {
-    Seq(
-      ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;.*BuildInfo.*;.*Routes.*;.*RoutesPrefix.*",
-      ScoverageKeys.coverageMinimumStmtTotal := 95,
-      ScoverageKeys.coverageFailOnMinimum := false,
-      ScoverageKeys.coverageHighlighting := true
-    )
-  }
+
+  val excludedPackages: Seq[String] = Seq(
+    "<empty>",
+    "Reverse.*",
+    ".*BuildInfo.*",
+    ".*Routes.*",
+    ".*RoutesPrefix.*"
+  )
+
+  def apply(): Seq[Setting[?]] = Seq(
+    ScoverageKeys.coverageMinimumStmtTotal := 94,
+    ScoverageKeys.coverageFailOnMinimum := true,
+    ScoverageKeys.coverageHighlighting := true,
+    ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";")
+  )
+
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"         % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"     % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"             % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin"             % "3.0.7")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"          % "2.3.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"           % "2.5.4")
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"         % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"     % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"             % "3.0.3")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"          % "2.0.11")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"           % "2.5.2")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"     % "2.6.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"             % "3.0.6")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"          % "2.3.1")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"           % "2.5.4")
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"   % "0.10.0-RC1")

--- a/test/uk/gov/hmrc/emailverification/controllers/EmailVerificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/controllers/EmailVerificationControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emailverification.controllers
 
 import config.AppConfig
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.Mockito._
 import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
@@ -119,7 +120,7 @@ class EmailVerificationControllerSpec extends UnitSpec {
       contentAsJson(response).as[VerifiedEmail] shouldBe VerifiedEmail(emailMixedCase)
       verify(mockVerifiedEmailService).find(eqTo(emailMixedCase))
       verifyNoMoreInteractions(mockVerifiedEmailService)
-      verify(mockAuditService).sendCheckEmailVerifiedEvent(*, *, eqTo(OK))(*)
+      verify(mockAuditService).sendCheckEmailVerifiedEvent(any, any, eqTo(OK))(any)
     }
 
     "lower case email address" in new Setup {
@@ -129,7 +130,7 @@ class EmailVerificationControllerSpec extends UnitSpec {
       contentAsJson(response).as[VerifiedEmail] shouldBe VerifiedEmail(emailMixedCase)
       verify(mockVerifiedEmailService).find(eqTo(emailMixedCase.toUpperCase))
       verifyNoMoreInteractions(mockVerifiedEmailService)
-      verify(mockAuditService).sendCheckEmailVerifiedEvent(*, *, eqTo(OK))(*)
+      verify(mockAuditService).sendCheckEmailVerifiedEvent(any, any, eqTo(OK))(any)
     }
 
     "return 404 if email not found" in new Setup {
@@ -138,7 +139,7 @@ class EmailVerificationControllerSpec extends UnitSpec {
       status(response) shouldBe 404
       verify(mockVerifiedEmailService).find(eqTo(emailMixedCase))
       verifyNoMoreInteractions(mockVerifiedEmailService)
-      verify(mockAuditService).sendCheckEmailVerifiedEvent(*, *, eqTo(NOT_FOUND))(*)
+      verify(mockAuditService).sendCheckEmailVerifiedEvent(any, any, eqTo(NOT_FOUND))(any)
     }
   }
 

--- a/test/uk/gov/hmrc/emailverification/repositories/PasscodeMongoRepositorySpec.scala
+++ b/test/uk/gov/hmrc/emailverification/repositories/PasscodeMongoRepositorySpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emailverification.repositories
 
 import config.AppConfig
+import org.mockito.Mockito.when
 import uk.gov.hmrc.emailverification.models.PasscodeDoc
 import uk.gov.hmrc.http.SessionId
 

--- a/test/uk/gov/hmrc/emailverification/repositories/VerificationCodeV2MongoRepositorySpec.scala
+++ b/test/uk/gov/hmrc/emailverification/repositories/VerificationCodeV2MongoRepositorySpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emailverification.repositories
 
 import config.AppConfig
+import org.mockito.Mockito.when
 import uk.gov.hmrc.emailverification.models.VerificationCodeMongoDoc
 import uk.gov.hmrc.mongo.CurrentTimestampSupport
 

--- a/test/uk/gov/hmrc/emailverification/repositories/VerifiedHashedEmailMongoRepositorySpec.scala
+++ b/test/uk/gov/hmrc/emailverification/repositories/VerifiedHashedEmailMongoRepositorySpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.emailverification.repositories
 
 import com.mongodb.MongoException
 import config.AppConfig
+import org.mockito.Mockito.when
 import org.mongodb.scala.bson.{BsonBoolean, BsonString}
 import uk.gov.hmrc.emailverification.models.VerifiedEmail
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/uk/gov/hmrc/emailverification/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/AuditServiceSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.emailverification.services
 
+import org.mockito.ArgumentMatchersSugar.any
+import org.mockito.Mockito.{verify, when}
 import org.mockito.captor.ArgCaptor
 import org.scalatest.Assertion
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite

--- a/test/uk/gov/hmrc/emailverification/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/EmailServiceSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.emailverification.services
 
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.Mockito.when
 import uk.gov.hmrc.emailverification.connectors.EmailConnector
 import uk.gov.hmrc.emailverification.models.{English, Welsh}
 import uk.gov.hmrc.gg.test.UnitSpec

--- a/test/uk/gov/hmrc/emailverification/services/EmailVerificationV2ServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/EmailVerificationV2ServiceSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emailverification.services
 
 import config.AppConfig
+import org.mockito.Mockito.when
 import org.mockito.{ArgumentMatchers => AM}
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.emailverification.models.{English, SendCodeResult, SendCodeV2Request, UserAgent, VerifyCodeResult, VerifyCodeV2Request}

--- a/test/uk/gov/hmrc/emailverification/services/JourneyServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/JourneyServiceSpec.scala
@@ -17,6 +17,9 @@
 package uk.gov.hmrc.emailverification.services
 
 import config.AppConfig
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.Mockito.{verify, when}
+import org.mockito.MockitoSugar.verifyZeroInteractions
 
 import java.util.UUID
 import org.mockito.captor.{ArgCaptor, Captor}

--- a/test/uk/gov/hmrc/emailverification/services/VerificationLinkServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/VerificationLinkServiceSpec.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.emailverification.services
 
 import com.typesafe.config.Config
 import config.AppConfig
+import org.mockito.Mockito.when
+import org.mockito.stubbing.ScalaFirstStubbing.toScalaFirstStubbing
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter}

--- a/test/uk/gov/hmrc/emailverification/services/VerifiedEmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/VerifiedEmailServiceSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emailverification.services
 
 import config.AppConfig
+import org.mockito.Mockito.when
 import uk.gov.hmrc.emailverification.models.VerifiedEmail
 import uk.gov.hmrc.emailverification.repositories.{RepositoryBaseSpec, VerifiedHashedEmailMongoRepository}
 import uk.gov.hmrc.http.HeaderCarrier


### PR DESCRIPTION
The majority of the platops-pr-bot suggestions have been applied apart from these 2 :-

- You have multiple routes files conf/app.routes, conf/appV2.routes, conf/testOnlyDoNotUseInAppConf.routes using the same package uk.gov.hmrc.emailverification.controllers, which leads to collision with the reverse routes. Please ensure each routes file refers to a different package.

- uk.gov.hmrc:government-gateway-test-play-30 in [project/AppDependencies.scala](https://github.com/hmrc/email-verification/blob/CIR-2099/project/AppDependencies.scala#L13) can be removed, it should be replaced by com.vladsch.flexmark:flexmark-all if needed