### PR TITLE
[CIR-2149] Add the Cy and En labels to the stored Journey Data

### DIFF
--- a/app/uk/gov/hmrc/emailverification/models/Journey.scala
+++ b/app/uk/gov/hmrc/emailverification/models/Journey.scala
@@ -35,7 +35,8 @@ case class Journey(
   passcode: String,
   emailAddressAttempts: Int,
   passcodesSentToEmail: Int,
-  passcodeAttempts: Int
+  passcodeAttempts: Int,
+  labels: Option[Labels]
 ) {
   def frontendData: JourneyData = JourneyData(
     accessibilityStatementUrl,
@@ -43,7 +44,8 @@ case class Journey(
     enterEmailUrl,
     backUrl,
     pageTitle,
-    emailAddress
+    emailAddress,
+    labels
   )
 }
 

--- a/app/uk/gov/hmrc/emailverification/models/JourneyData.scala
+++ b/app/uk/gov/hmrc/emailverification/models/JourneyData.scala
@@ -26,7 +26,8 @@ case class JourneyData(
   enterEmailUrl: Option[String],
   backUrl: Option[String],
   serviceTitle: Option[String],
-  emailAddress: Option[String]
+  emailAddress: Option[String],
+  labels: Option[Labels]
 )
 
 object JourneyData {

--- a/app/uk/gov/hmrc/emailverification/models/VerifyEmailRequest.scala
+++ b/app/uk/gov/hmrc/emailverification/models/VerifyEmailRequest.scala
@@ -45,9 +45,9 @@ object VerifyEmailRequest {
 }
 
 object Label {
-  implicit val reads: Reads[Label] = Json.reads
+  implicit val format: Format[Label] = Json.format
 }
 
 object Labels {
-  implicit val reads: Reads[Labels] = Json.reads
+  implicit val format: Format[Labels] = Json.format
 }

--- a/app/uk/gov/hmrc/emailverification/repositories/JourneyRepository.scala
+++ b/app/uk/gov/hmrc/emailverification/repositories/JourneyRepository.scala
@@ -20,10 +20,11 @@ import com.google.inject.ImplementedBy
 import org.mongodb.scala.model.IndexModel
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.emailverification.models.{Journey, Language}
+import uk.gov.hmrc.emailverification.models.{Journey, Labels, Language}
 import org.mongodb.scala.model._
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
@@ -73,7 +74,8 @@ class JourneyMongoRepository @Inject() (mongoComponent: MongoComponent)(implicit
           createdAt = Instant.now(),
           emailAddressAttempts = journey.emailAddressAttempts,
           passcodesSentToEmail = journey.passcodesSentToEmail,
-          passcodeAttempts = 0
+          passcodeAttempts = 0,
+          labels = journey.labels
         )
       )
       .toFuture()
@@ -161,7 +163,8 @@ object JourneyMongoRepository {
     createdAt: Instant,
     emailAddressAttempts: Int,
     passcodesSentToEmail: Int,
-    passcodeAttempts: Int
+    passcodeAttempts: Int,
+    labels: Option[Labels] // Added as option for non-breaking backwards compatibility for pre-existing journeys
   ) {
     def toJourney: Journey = Journey(
       journeyId,
@@ -178,7 +181,8 @@ object JourneyMongoRepository {
       passcode,
       emailAddressAttempts,
       passcodesSentToEmail,
-      passcodeAttempts
+      passcodeAttempts,
+      labels
     )
   }
 
@@ -198,6 +202,7 @@ object JourneyMongoRepository {
       (__ \ "createdAt").format[Instant](uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats.instantFormat) and
       (__ \ "emailAddressAttempts").format[Int] and
       (__ \ "passcodesSentToEmail").format[Int] and
-      (__ \ "passcodeAttempts").format[Int]
+      (__ \ "passcodeAttempts").format[Int] and
+      (__ \ "labels").formatNullable[Labels]
   )(Entity.apply, unlift(Entity.unapply))
 }

--- a/app/uk/gov/hmrc/emailverification/services/JourneyService.scala
+++ b/app/uk/gov/hmrc/emailverification/services/JourneyService.scala
@@ -66,7 +66,8 @@ class JourneyService @Inject() (
       passcode = passcode,
       emailAddressAttempts = emailAddressAttempts,
       passcodesSentToEmail = 0,
-      passcodeAttempts = 0
+      passcodeAttempts = 0,
+      labels = verifyEmailRequest.labels
     )
     for {
       _ <- journeyRepository.initialise(journey)

--- a/app/uk/gov/hmrc/emailverification/utils/JourneyLabelsUtil.scala
+++ b/app/uk/gov/hmrc/emailverification/utils/JourneyLabelsUtil.scala
@@ -16,22 +16,35 @@
 
 package uk.gov.hmrc.emailverification.utils
 
-import uk.gov.hmrc.emailverification.models.VerifyEmailRequest
+import uk.gov.hmrc.emailverification.models.{VerifyEmailRequest, Welsh}
 
 object JourneyLabelsUtil {
 
   def getTeamNameLabel(verifyEmailRequest: VerifyEmailRequest): String = {
-    val welsh = verifyEmailRequest.labels.flatMap(_.cy.userFacingServiceName)
-    val english = verifyEmailRequest.labels.flatMap(_.en.userFacingServiceName)
+
+    val labels = verifyEmailRequest.labels
     val deskPro = verifyEmailRequest.deskproServiceName
     val origin = verifyEmailRequest.origin
-    welsh orElse english orElse deskPro getOrElse origin
+
+    val message = (verifyEmailRequest.lang, labels.map(_.en), labels.map(_.cy)) match {
+      case (Some(Welsh), _, Some(cy)) => cy.userFacingServiceName
+      case (_, None, Some(cy))        => cy.userFacingServiceName
+      case (_, en, _)                 => en.flatMap(_.userFacingServiceName)
+    }
+
+    message orElse deskPro getOrElse origin
   }
 
   def getPageTitleLabel(verifyEmailRequest: VerifyEmailRequest): Option[String] = {
-    val welsh = verifyEmailRequest.labels.flatMap(_.cy.pageTitle)
-    val english = verifyEmailRequest.labels.flatMap(_.en.pageTitle)
+    val labels = verifyEmailRequest.labels
     val maybePageTitle = verifyEmailRequest.pageTitle
-    welsh orElse english orElse maybePageTitle
+
+    val message = (verifyEmailRequest.lang, labels.map(_.en), labels.map(_.cy)) match {
+      case (Some(Welsh), _, Some(cy)) => cy.pageTitle
+      case (_, None, Some(cy))        => cy.pageTitle
+      case (_, en, _)                 => en.flatMap(_.pageTitle)
+    }
+
+    message orElse maybePageTitle
   }
 }

--- a/it/test/uk/gov/hmrc/emailverification/EmailPasscodeControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/emailverification/EmailPasscodeControllerISpec.scala
@@ -60,21 +60,22 @@ class EmailPasscodeControllerISpec extends BaseISpec with Eventually {
       expectUserToBeAuthorisedWithGG(credId)
 
       val journey: Journey = Journey(
-        UUID.randomUUID().toString,
-        credId,
-        "/continueUrl",
-        "origin",
-        "/accessibility",
-        "serviceName",
-        English,
+        journeyId = UUID.randomUUID().toString,
+        credId = credId,
+        continueUrl = "/continueUrl",
+        origin = "origin",
+        accessibilityStatementUrl = "/accessibility",
+        serviceName = "serviceName",
+        language = English,
         emailAddress = Some(generateUUID),
-        Some("/enterEmail"),
-        Some("/back"),
-        Some("title"),
+        enterEmailUrl = Some("/enterEmail"),
+        backUrl = Some("/back"),
+        pageTitle = Some("title"),
         passcode = passcode2,
-        0,
-        0,
-        0
+        emailAddressAttempts = 0,
+        passcodesSentToEmail = 0,
+        passcodeAttempts = 0,
+        labels = None
       )
 
       expectJourneyToExist(journey)
@@ -743,7 +744,8 @@ class EmailPasscodeControllerISpec extends BaseISpec with Eventually {
               createdAt = Instant.now(),
               emailAddressAttempts = journey.emailAddressAttempts,
               passcodesSentToEmail = journey.passcodesSentToEmail,
-              passcodeAttempts = journey.passcodeAttempts
+              passcodeAttempts = journey.passcodeAttempts,
+              labels = journey.labels
             )
           )
           .toFuture()

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,7 +1,7 @@
 import sbt.*
 
 object AppDependencies {
-  private val bootstrapVersion = "9.12.0"
+  private val bootstrapVersion = "9.14.0"
   private val hmrcMongoVersion = "2.6.0"
 
   private val compile: Seq[ModuleID] = Seq(
@@ -13,10 +13,10 @@ object AppDependencies {
     "uk.gov.hmrc"                  %% "government-gateway-test-play-30" % "7.1.0",
     "uk.gov.hmrc"                  %% "bootstrap-test-play-30"          % bootstrapVersion,
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-test-play-30"         % hmrcMongoVersion,
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"            % "2.17.0",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"            % "2.19.1",
     "org.scalatestplus"            %% "scalacheck-1-17"                 % "3.2.18.0",
     "com.vladsch.flexmark"          % "flexmark-all"                    % "0.64.8",
-    "org.mockito"                  %% "mockito-scala-scalatest"         % "1.17.30"
+    "org.mockito"                  %% "mockito-scala-scalatest"         % "2.0.0"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"         % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"     % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"             % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin"             % "3.0.8")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"          % "2.3.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"           % "2.5.4")
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))

--- a/test/uk/gov/hmrc/emailverification/repositories/JourneyRepositorySpec.scala
+++ b/test/uk/gov/hmrc/emailverification/repositories/JourneyRepositorySpec.scala
@@ -46,7 +46,8 @@ class JourneyRepositorySpec extends RepositoryBaseSpec {
         "passcode",
         1,
         passcodesSentToEmail = 1,
-        passcodeAttempts = 0
+        passcodeAttempts = 0,
+        labels = None
       )
 
       whenReady(repository.initialise(testJourney)) { value =>
@@ -77,7 +78,8 @@ class JourneyRepositorySpec extends RepositoryBaseSpec {
         "passcode",
         1,
         passcodesSentToEmail = 1,
-        passcodeAttempts = 0
+        passcodeAttempts = 0,
+        labels = None
       )
 
       whenReady(repository.initialise(testJourney)) { value =>
@@ -104,7 +106,8 @@ class JourneyRepositorySpec extends RepositoryBaseSpec {
         "passcode",
         1,
         passcodesSentToEmail = 1,
-        passcodeAttempts = 0
+        passcodeAttempts = 0,
+        labels = None
       )
 
       whenReady(repository.initialise(testJourney)) { value =>
@@ -133,7 +136,8 @@ class JourneyRepositorySpec extends RepositoryBaseSpec {
       "passcode",
       1,
       passcodesSentToEmail = 1,
-      passcodeAttempts = 0
+      passcodeAttempts = 0,
+      labels = None
     )
     val testJourney2 = testJourney1.copy(journeyId = "journeyId2")
     val testJourney3 = testJourney1.copy(journeyId = "journeyId3", credId = "credId2")

--- a/test/uk/gov/hmrc/emailverification/services/JourneyServiceSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/services/JourneyServiceSpec.scala
@@ -343,7 +343,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 0,
-                passcodeAttempts = 0
+                passcodeAttempts = 0,
+                labels = None
               )
             )
           )
@@ -367,7 +368,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 0,
-                passcodeAttempts = 0
+                passcodeAttempts = 0,
+                labels = None
               )
             )
           )
@@ -440,7 +442,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 0,
-                passcodeAttempts = 0
+                passcodeAttempts = 0,
+                labels = None
               )
             )
           )
@@ -477,7 +480,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 2,
-                passcodeAttempts = 2
+                passcodeAttempts = 2,
+                labels = None
               )
             )
           )
@@ -487,7 +491,7 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
         when(mockVerificationStatusRepository.lock(eqTo("credId"), eqTo(email))).thenReturn(Future.unit)
 
         val result: ResendPasscodeResult = await(journeyService.resendPasscode(journeyId)(HeaderCarrier()))
-        result shouldBe ResendPasscodeResult.TooManyAttemptsForEmail(JourneyData("/accessibility", serviceName, Some("/enterEmail"), None, None, Some(email)))
+        result shouldBe ResendPasscodeResult.TooManyAttemptsForEmail(JourneyData("/accessibility", serviceName, Some("/enterEmail"), None, None, Some(email), None))
       }
     }
 
@@ -515,7 +519,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 1,
-                passcodeAttempts = 2
+                passcodeAttempts = 2,
+                labels = None
               )
             )
           )
@@ -552,7 +557,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 1,
-                passcodeAttempts = 1
+                passcodeAttempts = 1,
+                labels = None
               )
             )
           )
@@ -601,7 +607,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 0,
-                passcodeAttempts = 2
+                passcodeAttempts = 2,
+                labels = None
               )
             )
           )
@@ -640,7 +647,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 0,
-                passcodeAttempts = 0
+                passcodeAttempts = 0,
+                labels = None
               )
             )
           )
@@ -648,7 +656,7 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
         when(mockAppConfig.maxPasscodeAttempts).thenReturn(100)
 
         val result: PasscodeValidationResult = await(journeyService.validatePasscode(journeyId, credId, passcode.reverse))
-        result shouldBe PasscodeValidationResult.IncorrectPasscode(JourneyData("/accessibility", "some service", enterEmailUrl, None, None, Some("aa@bb.cc")))
+        result shouldBe PasscodeValidationResult.IncorrectPasscode(JourneyData("/accessibility", "some service", enterEmailUrl, None, None, Some("aa@bb.cc"), None))
       }
     }
 
@@ -675,7 +683,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
                 passcode = passcode,
                 emailAddressAttempts = 1,
                 passcodesSentToEmail = 0,
-                passcodeAttempts = 0
+                passcodeAttempts = 0,
+                labels = None
               )
             )
           )
@@ -780,7 +789,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
       passcode = passcode,
       emailAddressAttempts = 0,
       passcodesSentToEmail = 0,
-      passcodeAttempts = 0
+      passcodeAttempts = 0,
+      labels = None
     )
 
     def createTestJourney(credId: String, email: Option[String], emailAddressAttempts: Int, passcodesSentToEmail: Int) = new Journey(
@@ -798,7 +808,8 @@ class JourneyServiceSpec extends UnitSpec with ScalaFutures {
       passcode = passcode,
       emailAddressAttempts = emailAddressAttempts,
       passcodesSentToEmail = passcodesSentToEmail,
-      passcodeAttempts = 0
+      passcodeAttempts = 0,
+      labels = None
     )
   }
 

--- a/test/uk/gov/hmrc/emailverification/utils/JourneyLabelsUtilSpec.scala
+++ b/test/uk/gov/hmrc/emailverification/utils/JourneyLabelsUtilSpec.scala
@@ -18,72 +18,171 @@ package uk.gov.hmrc.emailverification.utils
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.emailverification.models.{Label, Labels, VerifyEmailRequest}
+import uk.gov.hmrc.emailverification.models.{Label, Labels, VerifyEmailRequest, Welsh}
 import uk.gov.hmrc.emailverification.utils.JourneyLabelsUtil.{getPageTitleLabel, getTeamNameLabel}
 
 class JourneyLabelsUtilSpec extends AnyWordSpec with Matchers {
 
   "getTeamNameLabel" should {
-    "return the Welsh team name when Welsh label exist" in {
-      val labels = Some(Labels(cy = Label(null, Some("Welsh Team Name")), en = Label(null, Some("English Team Name"))))
-      val request = VerifyEmailRequest(null, null, "origin", Some("DeskPro Name"), null, null, null, null, null, labels)
+    "return the Welsh team name when Welsh label exist and language is set to Welsh" in {
+      val labels = Some(Labels(cy = Label(None, Some("Welsh Team Name")), en = Label(None, Some("English Team Name"))))
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = Some("DeskPro Name"),
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = Some(Welsh),
+        backUrl = None,
+        pageTitle = None,
+        labels = labels
+      )
 
       getTeamNameLabel(request) shouldBe "Welsh Team Name"
     }
 
     "return the English team name when Welsh does not exist but English" in {
-      val labels = Some(Labels(cy = Label(null, None), en = Label(null, Some("English Team Name"))))
-      val request = VerifyEmailRequest(null, null, "origin", Some("DeskPro Name"), null, null, null, null, null, labels)
+      val labels = Some(Labels(cy = Label(None, None), en = Label(None, Some("English Team Name"))))
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = Some("DeskPro Name"),
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = None,
+        labels = labels
+      )
 
       getTeamNameLabel(request) shouldBe "English Team Name"
     }
 
     "return the DeskPro name when Welsh nor English does not exist but DeskPro" in {
-      val labels = Some(Labels(cy = Label(null, None), en = Label(null, None)))
-      val request = VerifyEmailRequest(null, null, "origin", Some("DeskPro Name"), null, null, null, null, null, labels)
+      val labels = Some(Labels(cy = Label(None, None), en = Label(None, None)))
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = Some("DeskPro Name"),
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = None,
+        labels = labels
+      )
 
       getTeamNameLabel(request) shouldBe "DeskPro Name"
     }
 
     "return the origin when Welsh, English nor DeskPro does not exist" in {
-      val labels = Some(Labels(cy = Label(null, None), en = Label(null, None)))
-      val request = VerifyEmailRequest(null, null, "origin", None, null, null, null, null, null, labels)
+      val labels = Some(Labels(cy = Label(None, None), en = Label(None, None)))
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = None,
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = None,
+        labels = labels
+      )
 
       getTeamNameLabel(request) shouldBe "origin"
     }
 
     "return the DeskPro Name when the labels field does not exist" in {
-      val request = VerifyEmailRequest(null, null, "origin", Some("DeskPro Name"), null, null, null, null, null, None)
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = Some("DeskPro Name"),
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = None,
+        labels = None
+      )
 
       getTeamNameLabel(request) shouldBe "DeskPro Name"
     }
   }
 
   "getPageTitleLabel" should {
-    "return the Welsh title when Welsh label exist" in {
+    "return the Welsh title when Welsh label exist and language is set to Welsh" in {
       val labels = Some(Labels(cy = Label(Some("Welsh Title"), null), en = Label(Some("English Title"), null)))
-      val request = VerifyEmailRequest(null, null, null, null, null, null, null, null, Some("Page Title"), labels)
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = None,
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = Some(Welsh),
+        backUrl = None,
+        pageTitle = Some("Page Title"),
+        labels = labels
+      )
 
       getPageTitleLabel(request) shouldBe Some("Welsh Title")
     }
 
     "return the English title when Welsh does not exist but English" in {
       val labels = Some(Labels(cy = Label(None, null), en = Label(Some("English Title"), null)))
-      val request = VerifyEmailRequest(null, null, null, null, null, null, null, null, Some("Page Title"), labels)
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = None,
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = Some("Page Title"),
+        labels = labels
+      )
 
       getPageTitleLabel(request) shouldBe Some("English Title")
     }
 
     "return the Page title when Welsh nor English label does not exist" in {
       val labels = Some(Labels(cy = Label(None, null), en = Label(None, null)))
-      val request = VerifyEmailRequest(null, null, null, null, null, null, null, null, Some("Page Title"), labels)
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = None,
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = Some("Page Title"),
+        labels = labels
+      )
 
       getPageTitleLabel(request) shouldBe Some("Page Title")
     }
 
     "return the None when Welsh, English nor Page Title does not exist" in {
       val labels = Some(Labels(cy = Label(None, null), en = Label(None, null)))
-      val request = VerifyEmailRequest(null, null, null, null, null, null, null, null, None, labels)
+      val request = VerifyEmailRequest(
+        credId = "cred-1234",
+        continueUrl = "/continue",
+        origin = "origin",
+        deskproServiceName = None,
+        accessibilityStatementUrl = "/a11y",
+        email = None,
+        lang = None,
+        backUrl = None,
+        pageTitle = None,
+        labels = labels
+      )
 
       getPageTitleLabel(request) shouldBe None
     }


### PR DESCRIPTION
This change stores the Cy and En labels as part of the Journey Data so that the Frontend can make an informed decision about which language to render based on the Cookie.

Having this responsibility for determining content as being delegated to the BE didn't make sense before, and would lock a User into a particular language (even if they tried to switch language).

There is an associated email-verification-frontend PR that needs to be reviewed and merged alongside this:
- https://github.com/hmrc/email-verification-frontend/pull/78

